### PR TITLE
improve target decision compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,7 @@ jobs:
         run: |
           chmod +x ./gradlew
           ./gradlew :module:assembleRelease
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ZygiskFrida
+          path: out/magisk_module_release/

--- a/module.gradle
+++ b/module.gradle
@@ -5,7 +5,7 @@ ext {
     moduleName = "ZygiskFrida"
     moduleAuthor = "lico-n"
     moduleDescription = "Injects frida gadget via zygisk."
-    moduleVersion = "v1.0.0"
+    moduleVersion = "v1.1.0"
     moduleVersionCode = 1
     modulePackageName = "re.zyg.fri"
 

--- a/template/magisk_module/customize.sh
+++ b/template/magisk_module/customize.sh
@@ -4,6 +4,8 @@ mkdir -p \$TMP_MODULE_DIR
 
 cp \$MODPATH/gadget/libgadget-\$ARCH.so.xz \$TMP_MODULE_DIR/${gadgetLibraryName}.xz
 /data/adb/magisk/busybox unxz \$TMP_MODULE_DIR/${gadgetLibraryName}.xz
+rm \$TMP_MODULE_DIR/${gadgetLibraryName}.xz
+
 touch \$TMP_MODULE_DIR/target_packages
 
 set_perm_recursive \$TMP_MODULE_DIR 0 0 0755 0644


### PR DESCRIPTION
Some devices seems to be unable to access the `target_packages` file in `preAppSpecialize` which runs under a different context than `postAppSpecialize`. 

For improved compatibility, reading the `target_packages`  is moved to `postAppSpecialize`.