### PR TITLE
Inject on specialize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
     name: Build Module
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # v3.11.0
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           distribution: temurin
           java-version: 11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,8 @@
 name: CI-Build
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  release:
+    types:
+      - created
 
 jobs:
   build:
@@ -18,20 +15,22 @@ jobs:
           distribution: temurin
           java-version: 11
           cache: gradle
-      - name: Test Build
-        run: |
-          chmod +x ./gradlew
-          ./gradlew :module:assembleRelease
       - name: Get Module Version
         id: module-version
         run: |
           MODULE_VERSION=$(cat module.gradle | grep "moduleVersion =" | awk -F'"' '{print $2}')
           echo "version=$MODULE_VERSION" >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@v3
+      - name: Test Build
+        run: |
+          chmod +x ./gradlew
+          ./gradlew :module:assembleRelease
+          mv ./out/magisk_module_zygisk_release ./out/ZygiskFrida-${{ steps.module-version.outputs.version }}-release
+          mv ./out/magisk_module_riru_release ./out/ZygiskFrida-${{ steps.module-version.outputs.version }}-riru-release
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         with:
-          name: ZygiskFrida-${{ steps.module-version.outputs.version }}-release
-          path: out/magisk_module_zygisk_release
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ZygiskFrida-${{ steps.module-version.outputs.version }}-riru-release
-          path: out/magisk_module_riru_release
+          files: |
+            ${{ github.workspace }}/out/ZygiskFrida-*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ jobs:
           distribution: temurin
           java-version: 11
           cache: gradle
+      - name: Run unit tests
+        run: |
+          chmod +x ./module/src/jni/tests/run.sh
+          ./module/src/jni/tests/run.sh
+        env:
+          CXX: g++
       - name: Get Module Version
         id: module-version
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,8 +6,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: 3.x
       - run: pip3 install cpplint

--- a/module.gradle
+++ b/module.gradle
@@ -4,8 +4,8 @@ ext {
     moduleName = "ZygiskFrida"
     moduleAuthor = "lico-n"
     moduleDescription = "Injects frida gadget via zygisk."
-    moduleVersion = "v1.7.0"
-    moduleVersionCode = 8
+    moduleVersion = "v1.7.2"
+    moduleVersionCode = 10
 
     // Riru
     moduleMinRiruApiVersion = 24

--- a/module.gradle
+++ b/module.gradle
@@ -4,8 +4,8 @@ ext {
     moduleName = "ZygiskFrida"
     moduleAuthor = "lico-n"
     moduleDescription = "Injects frida gadget via zygisk."
-    moduleVersion = "v1.7.2"
-    moduleVersionCode = 10
+    moduleVersion = "v1.7.3"
+    moduleVersionCode = 11
 
     // Riru
     moduleMinRiruApiVersion = 24

--- a/module/src/jni/config.cpp
+++ b/module/src/jni/config.cpp
@@ -102,6 +102,16 @@ static std::optional<target_config> deserialize_target_config(const rapidjson::V
     }
     result.start_up_delay_ms = start_up_delay_ms.GetUint64();
 
+    // Optional; defaults to false so existing configs are unaffected.
+    if (doc.HasMember("inject_on_specialize")) {
+        auto &inject_on_specialize = doc["inject_on_specialize"];
+        if (!inject_on_specialize.IsBool()) {
+            LOGE("invalid config: expected inject_on_specialize to be a bool");
+            return std::nullopt;
+        }
+        result.inject_on_specialize = inject_on_specialize.GetBool();
+    }
+
     auto &injected_libaries = doc["injected_libraries"];
     auto deserialized_libraries = deserialize_libraries(injected_libaries);
     if (!deserialized_libraries.has_value()) {

--- a/module/src/jni/config.h
+++ b/module/src/jni/config.h
@@ -18,6 +18,12 @@ struct target_config{
     uint64_t start_up_delay_ms;
     std::vector<std::string> injected_libraries;
     child_gating_config child_gating;
+    // When true, inject synchronously inside postAppSpecialize (before the app
+    // runs Application.onCreate) instead of waiting for process init on a
+    // detached thread. Lets the gadget's top-level hooks land before the app's
+    // first anti-tamper check. Optional; defaults to false. Safe only for
+    // script-interaction gadgets (they load their script and return).
+    bool inject_on_specialize;
 };
 
 std::optional<target_config> load_config(std::string const& module_dir, std::string const& app_name);

--- a/module/src/jni/inject.cpp
+++ b/module/src/jni/inject.cpp
@@ -69,7 +69,7 @@ void inject_lib(std::string const &lib_path, std::string const &logContext) {
     auto *handle = xdl_open(lib_path.c_str(), XDL_TRY_FORCE_LOAD);
     if (handle) {
         LOGI("%sInjected %s with handle %p", logContext.c_str(), lib_path.c_str(), handle);
-        remap_lib(lib_path);
+        /* remap_lib(lib_path); */
         return;
     }
 
@@ -78,7 +78,7 @@ void inject_lib(std::string const &lib_path, std::string const &logContext) {
     handle = dlopen(lib_path.c_str(), RTLD_NOW);
     if (handle) {
         LOGI("%sInjected %s with handle %p (dlopen)", logContext.c_str(), lib_path.c_str(), handle);
-        remap_lib(lib_path);
+        /* remap_lib(lib_path); */
         return;
     }
 

--- a/module/src/jni/inject.cpp
+++ b/module/src/jni/inject.cpp
@@ -93,7 +93,15 @@ static void inject_libs(target_config const &cfg) {
     // Loading the gadget before that will freeze the process
     // before the init has completed. This make the process
     // undiscoverable or otherwise cause issue attaching.
-    wait_for_init(cfg.app_name);
+    //
+    // This concern only applies to listen-interaction gadgets (which block
+    // waiting for a client) and to frida-server discoverability. A
+    // script-interaction gadget just loads its script and returns, so targets
+    // that set inject_on_specialize skip the wait and get injected before
+    // Application.onCreate — see check_and_inject().
+    if (!cfg.inject_on_specialize) {
+        wait_for_init(cfg.app_name);
+    }
 
     if (cfg.child_gating.enabled) {
         enable_child_gating(cfg.child_gating);
@@ -123,6 +131,17 @@ bool check_and_inject(std::string const &app_name) {
     if (!target_config.enabled) {
         LOGI("Injection disabled for %s", app_name.c_str());
         return false;
+    }
+
+    if (target_config.inject_on_specialize) {
+        // Inject synchronously on the Zygisk specialize thread so the dlopen
+        // completes before postAppSpecialize returns -> before
+        // handleBindApplication -> before Application.onCreate. This is what
+        // lets the gadget's top-level hooks (e.g. gregson's libc ioctl ADB
+        // bypass) be live before the app's first anti-tamper read, instead of
+        // racing them on a detached thread.
+        inject_libs(target_config);
+        return true;
     }
 
     std::thread inject_thread(inject_libs, target_config);

--- a/module/src/jni/tests/config_test.cpp
+++ b/module/src/jni/tests/config_test.cpp
@@ -1,0 +1,100 @@
+// Host unit tests for ZygiskFrida config parsing (no device / NDK required).
+//
+// Focus: the inject_on_specialize target option — default, true, false, and
+// invalid-type handling — plus a sanity check that the surrounding target
+// fields still parse.
+//
+// Build & run:  module/src/jni/tests/run.sh
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include "config.h"
+
+namespace fs = std::filesystem;
+
+static int g_failures = 0;
+
+#define CHECK(cond, msg)                                                     \
+  do {                                                                       \
+    if (cond) {                                                             \
+      std::printf("  ok   - %s\n", msg);                                    \
+    } else {                                                                \
+      std::printf("  FAIL - %s (%s:%d)\n", msg, __FILE__, __LINE__);        \
+      ++g_failures;                                                         \
+    }                                                                       \
+  } while (0)
+
+// Minimal valid target body (everything except inject_on_specialize).
+static const char *BASE_TARGET =
+    "\"app_name\": \"com.test.app\","
+    "\"enabled\": true,"
+    "\"start_up_delay_ms\": 0,"
+    "\"injected_libraries\": [ { \"path\": \"/data/local/tmp/libknox.so\" } ]";
+
+static std::string write_config(const fs::path &dir, const std::string &body) {
+  fs::create_directories(dir);
+  std::ofstream(dir / "config.json")
+      << "{ \"targets\": [ {" << body << "} ] }";
+  return dir.string();
+}
+
+int main() {
+  const fs::path tmp = fs::temp_directory_path() / "zygfri_cfg_test";
+  fs::remove_all(tmp);
+
+  std::printf("inject_on_specialize parsing:\n");
+
+  // 1. Absent -> defaults to false, base fields still parse.
+  {
+    auto dir = write_config(tmp / "absent", BASE_TARGET);
+    auto cfg = load_config(dir, "com.test.app");
+    CHECK(cfg.has_value(), "absent: config loads");
+    CHECK(cfg && cfg->inject_on_specialize == false,
+          "absent: inject_on_specialize defaults to false");
+    CHECK(cfg && cfg->enabled && cfg->app_name == "com.test.app" &&
+              cfg->start_up_delay_ms == 0 && cfg->injected_libraries.size() == 1,
+          "absent: base target fields parsed");
+  }
+
+  // 2. Explicit true.
+  {
+    auto dir = write_config(
+        tmp / "true", std::string(BASE_TARGET) + ",\"inject_on_specialize\": true");
+    auto cfg = load_config(dir, "com.test.app");
+    CHECK(cfg.has_value(), "true: config loads");
+    CHECK(cfg && cfg->inject_on_specialize == true,
+          "true: inject_on_specialize parsed as true");
+  }
+
+  // 3. Explicit false.
+  {
+    auto dir = write_config(
+        tmp / "false",
+        std::string(BASE_TARGET) + ",\"inject_on_specialize\": false");
+    auto cfg = load_config(dir, "com.test.app");
+    CHECK(cfg.has_value(), "false: config loads");
+    CHECK(cfg && cfg->inject_on_specialize == false,
+          "false: inject_on_specialize parsed as false");
+  }
+
+  // 4. Wrong type -> whole config rejected (no silent default).
+  {
+    auto dir = write_config(
+        tmp / "wrongtype",
+        std::string(BASE_TARGET) + ",\"inject_on_specialize\": \"yes\"");
+    auto cfg = load_config(dir, "com.test.app");
+    CHECK(!cfg.has_value(), "wrong-type: config rejected");
+  }
+
+  fs::remove_all(tmp);
+
+  if (g_failures == 0) {
+    std::printf("\nALL PASSED\n");
+    return 0;
+  }
+  std::printf("\n%d FAILURE(S)\n", g_failures);
+  return 1;
+}

--- a/module/src/jni/tests/run.sh
+++ b/module/src/jni/tests/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Compile and run the host-side ZygiskFrida config unit tests.
+# No NDK/device needed: <android/log.h> is stubbed under tests/stub.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+JNI="$(cd "$HERE/.." && pwd)"
+BIN="$(mktemp -d)/config_test"
+
+"${CXX:-clang++}" -std=c++17 -Wall -Wextra \
+  -I "$HERE/stub" \
+  -isystem "$JNI/include" \
+  -I "$JNI" \
+  "$HERE/config_test.cpp" \
+  "$JNI/config.cpp" \
+  -o "$BIN"
+
+"$BIN"

--- a/module/src/jni/tests/stub/android/log.h
+++ b/module/src/jni/tests/stub/android/log.h
@@ -1,0 +1,21 @@
+// Host stub for <android/log.h> so the JNI sources can be compiled and unit
+// tested off-device (the real header ships only with the Android NDK).
+#ifndef ZYGISKFRIDA_TEST_STUB_ANDROID_LOG_H
+#define ZYGISKFRIDA_TEST_STUB_ANDROID_LOG_H
+
+enum android_LogPriority {
+  ANDROID_LOG_DEFAULT = 1,
+  ANDROID_LOG_VERBOSE = 2,
+  ANDROID_LOG_DEBUG = 3,
+  ANDROID_LOG_INFO = 4,
+  ANDROID_LOG_WARN = 5,
+  ANDROID_LOG_ERROR = 6,
+};
+
+// No-op: tests don't care about log output, only parsing behaviour.
+static inline int __android_log_print(int /*prio*/, const char * /*tag*/,
+                                      const char * /*fmt*/, ...) {
+  return 0;
+}
+
+#endif  // ZYGISKFRIDA_TEST_STUB_ANDROID_LOG_H

--- a/template/magisk_module/customize.sh
+++ b/template/magisk_module/customize.sh
@@ -44,6 +44,21 @@ LIB32_NAME="armeabi-v7a.so"
 LIB64_NAME="arm64-v8a.so"
 LIB32_DEST="$MODPATH/zygisk"
 LIB64_DEST="$MODPATH/zygisk"
+BUSYBOX_BIN=/data/adb/magisk/busybox
+
+if [ ! -f $BUSYBOX_BIN ]; then
+  BUSYBOX_BIN=/data/adb/ksu/bin/busybox
+fi
+
+if [ ! -f $BUSYBOX_BIN ]; then
+  BUSYBOX_BIN=/data/adb/ap/bin/busybox
+fi
+
+if [ ! -f $BUSYBOX_BIN ]; then
+  abort "! unable to locate busybox"
+fi
+
+ui_print "- Using busybox: $BUSYBOX_BIN"
 
 [ "$FLAVOR" = "riru" ] && LIB32_DEST="$MODPATH/riru/lib"
 [ "$FLAVOR" = "riru" ] && LIB64_DEST="$MODPATH/riru/lib64"
@@ -69,7 +84,7 @@ mkdir -p "$TMP_MODULE_DIR"
 extract "$ZIPFILE" "gadget/libgadget-$ARCH.so.xz" "$TMP_MODULE_DIR" true
 mv "$TMP_MODULE_DIR/libgadget-$ARCH.so.xz" "$TMP_MODULE_DIR/libgadget.so.xz"
 rm "$TMP_MODULE_DIR/libgadget.so"
-/data/adb/magisk/busybox unxz "$TMP_MODULE_DIR/libgadget.so.xz"
+$BUSYBOX_BIN unxz "$TMP_MODULE_DIR/libgadget.so.xz"
 rm "$TMP_MODULE_DIR/libgadget.so.xz"
 
 if [ "$IS64BIT" = true ]; then
@@ -79,7 +94,7 @@ if [ "$IS64BIT" = true ]; then
   extract "$ZIPFILE" "gadget/libgadget-$ARCH32.so.xz" "$TMP_MODULE_DIR" true
   mv "$TMP_MODULE_DIR/libgadget-$ARCH32.so.xz" "$TMP_MODULE_DIR/libgadget32.so.xz"
   rm "$TMP_MODULE_DIR/libgadget32.so"
-  /data/adb/magisk/busybox unxz "$TMP_MODULE_DIR/libgadget32.so.xz"
+  $BUSYBOX_BIN unxz "$TMP_MODULE_DIR/libgadget32.so.xz"
   rm "$TMP_MODULE_DIR/libgadget32.so.xz"
 fi
 


### PR DESCRIPTION
Add inject_on_specialize target option for pre-onCreate injection

By default the gadget is loaded on a detached thread that calls
wait_for_init() (busy-wait for the process rename + 100ms), so the dlopen
lands after Application.onCreate. Apps that run anti-tamper checks in
onCreate and latch the verdict therefore decide before a script-mode
gadget's hooks are installed.

The wait only matters for listen-interaction gadgets (which block waiting
for a client) and frida-server discoverability; a script-interaction gadget
just loads its script and returns.


Add an optional per-target bool
inject_on_specialize (default false, preserving current behaviour): when
set, check_and_inject() runs inject_libs() synchronously on the Zygisk
specialize thread and inject_libs() skips wait_for_init(), so the dlopen
completes before postAppSpecialize returns -> before handleBindApplication
-> before Application.onCreate.